### PR TITLE
Support selecting resources on Windows without WSL

### DIFF
--- a/src/Commands/FilamentResourceTestsCommand.php
+++ b/src/Commands/FilamentResourceTestsCommand.php
@@ -39,6 +39,16 @@ class FilamentResourceTestsCommand extends Command
             required: true,
         );
 
+        // check if the first selected item is numeric
+        // @see https://laravel.com/docs/11.x/prompts#fallbacks
+        if (!empty($selectedResources) && is_numeric($selectedResources[0] ?? null)) {
+            $selectedResources = collect($selectedResources)
+                ->mapWithKeys(fn($index) => [
+                    $availableResources->keys()->get($index) =>
+                        $availableResources->get($availableResources->keys()->get($index))
+                ]);
+        }
+
         foreach ($selectedResources as $selectedResource) {
             $resource = $this->getResourceClass($selectedResource);
 

--- a/src/Commands/FilamentResourceTestsCommand.php
+++ b/src/Commands/FilamentResourceTestsCommand.php
@@ -39,9 +39,11 @@ class FilamentResourceTestsCommand extends Command
             required: true,
         );
 
-        // check if the first selected item is numeric
+        // check if the first selected item is numeric (on windows without WSL multiselect returns an array of numeric strings)
         // @see https://laravel.com/docs/11.x/prompts#fallbacks
         if (!empty($selectedResources) && is_numeric($selectedResources[0] ?? null)) {
+
+            // convert the indexed selection back to the original resource path => resource name
             $selectedResources = collect($selectedResources)
                 ->mapWithKeys(fn($index) => [
                     $availableResources->keys()->get($index) =>


### PR DESCRIPTION
This PR simply check if the selection returned contains numeric values, then maps them to the correct resource