### PR TITLE
Add test for individually searchable columns

### DIFF
--- a/src/Commands/FilamentResourceTestsCommand.php
+++ b/src/Commands/FilamentResourceTestsCommand.php
@@ -141,6 +141,7 @@ class FilamentResourceTestsCommand extends Command
             'resourceTableToggleableColumns' => $this->convertDoubleQuotedArrayString($columns->filter(fn ($column) => $column->isToggleable())->keys()),
             'resourceTableSortableColumns' => $this->convertDoubleQuotedArrayString($columns->filter(fn ($column) => $column->isSortable())->keys()),
             'resourceTableSearchableColumns' => $this->convertDoubleQuotedArrayString($columns->filter(fn ($column) => $column->isSearchable())->keys()),
+            'resourceTableIndividuallySearchableColumns' => $this->convertDoubleQuotedArrayString($columns->filter(fn ($column) => $column->isIndividuallySearchable())->keys()),
         ];
     }
 

--- a/stubs/Resource.stub
+++ b/stubs/Resource.stub
@@ -51,5 +51,16 @@ it('can search column', function (string $column) {
         ->assertCanNotSeeTableRecords($records->where($column, '!=', $search));
 })->with($resourceTableSearchableColumns$);
 
+it('can individually search by column', function (string $column) {
+    $records = $modelSingularName$::factory()->count(3)->create();
+
+    $search = $records->first()->{$column};
+
+    livewire(List$modelPluralName$::class)
+        ->searchTableColumns([$column => $search])
+        ->assertCanSeeTableRecords($records->where($column, $search))
+        ->assertCanNotSeeTableRecords($records->where($column, '!=', $search));
+})->with($resourceTableIndividuallySearchableColumns$);
+
 
 


### PR DESCRIPTION
Note: If there are no individually searchable columns the test will be run `->with([])` which pest intern won't run (it will be ignored). This applies to all other tests btw.