### PR TITLE
Add a test that confirms `trashed` records are not shown by default

### DIFF
--- a/src/Commands/FilamentResourceTestsCommand.php
+++ b/src/Commands/FilamentResourceTestsCommand.php
@@ -142,7 +142,6 @@ class FilamentResourceTestsCommand extends Command
             'resourceTableSortableColumns' => $this->convertDoubleQuotedArrayString($columns->filter(fn ($column) => $column->isSortable())->keys()),
             'resourceTableSearchableColumns' => $this->convertDoubleQuotedArrayString($columns->filter(fn ($column) => $column->isSearchable())->keys()),
             'resourceTableIndividuallySearchableColumns' => $this->convertDoubleQuotedArrayString($columns->filter(fn ($column) => $column->isIndividuallySearchable())->keys()),
-            'modelUsesSoftDeletes' => method_exists($model, 'trashed'), // check if the model uses SoftDeletes trait
         ];
     }
 

--- a/src/Commands/FilamentResourceTestsCommand.php
+++ b/src/Commands/FilamentResourceTestsCommand.php
@@ -142,6 +142,7 @@ class FilamentResourceTestsCommand extends Command
             'resourceTableSortableColumns' => $this->convertDoubleQuotedArrayString($columns->filter(fn ($column) => $column->isSortable())->keys()),
             'resourceTableSearchableColumns' => $this->convertDoubleQuotedArrayString($columns->filter(fn ($column) => $column->isSearchable())->keys()),
             'resourceTableIndividuallySearchableColumns' => $this->convertDoubleQuotedArrayString($columns->filter(fn ($column) => $column->isIndividuallySearchable())->keys()),
+            'modelUsesSoftDeletes' => method_exists($model, 'trashed'), // check if the model uses SoftDeletes trait
         ];
     }
 

--- a/stubs/Resource.stub
+++ b/stubs/Resource.stub
@@ -63,4 +63,13 @@ it('can individually search by column', function (string $column) {
 })->with($resourceTableIndividuallySearchableColumns$);
 
 
+it('cannot display trashed records by default', function () {
+    $records = $modelSingularName$::factory()->count(3)->create();
 
+    $trashedRecords = $modelSingularName$::factory()->trashed()->count(6)->create();
+
+    livewire(List$modelPluralName$::class)
+        ->assertCanSeeTableRecords($records)
+        ->assertCanNotSeeTableRecords($trashedRecords)
+        ->assertCountTableRecords(3);
+})->skip(!$modelUsesSoftDeletes$, '$modelSingularName$ doesn\'t use SoftDeletes trait');

--- a/stubs/Resource.stub
+++ b/stubs/Resource.stub
@@ -3,6 +3,7 @@
 use App\Filament\Resources\$resource$\Pages\List$modelPluralName$;
 use $model$;
 use App\Models\User;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Hash;
 
 use function Pest\Laravel\actingAs;
@@ -10,6 +11,8 @@ use function Pest\Livewire\livewire;
 
 
 beforeEach(function () {
+    $this->modelUsesSoftDeletes = in_array(SoftDeletes::class, class_uses_recursive($modelSingularName$::class));
+
     actingAs(User::factory()->create([
         'password' => Hash::make('password'),
     ]));
@@ -72,4 +75,4 @@ it('cannot display trashed records by default', function () {
         ->assertCanSeeTableRecords($records)
         ->assertCanNotSeeTableRecords($trashedRecords)
         ->assertCountTableRecords(3);
-})->skip(!$modelUsesSoftDeletes$, '$modelSingularName$ doesn\'t use SoftDeletes trait');
+})->skip(fn () => ! $this->modelUsesSoftDeletes, '$modelSingularName$ does not use soft deletes');

--- a/stubs/Resource.stub
+++ b/stubs/Resource.stub
@@ -3,7 +3,6 @@
 use App\Filament\Resources\$resource$\Pages\List$modelPluralName$;
 use $model$;
 use App\Models\User;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Hash;
 
 use function Pest\Laravel\actingAs;
@@ -11,7 +10,7 @@ use function Pest\Livewire\livewire;
 
 
 beforeEach(function () {
-    $this->modelUsesSoftDeletes = in_array(SoftDeletes::class, class_uses_recursive($modelSingularName$::class));
+    $this->modelUsesSoftDeletes = method_exists(new $modelSingularName$(), 'bootSoftDeletes');
 
     actingAs(User::factory()->create([
         'password' => Hash::make('password'),


### PR DESCRIPTION
This PR checks if the model in question has an available `trashed` method which implies the use of the `SoftDeletes` trait

Depends on #45 