### PR TITLE
Add test to see if the `DeleteAction` works

### DIFF
--- a/src/Commands/FilamentResourceTestsCommand.php
+++ b/src/Commands/FilamentResourceTestsCommand.php
@@ -142,7 +142,6 @@ class FilamentResourceTestsCommand extends Command
             'resourceTableSortableColumns' => $this->convertDoubleQuotedArrayString($columns->filter(fn ($column) => $column->isSortable())->keys()),
             'resourceTableSearchableColumns' => $this->convertDoubleQuotedArrayString($columns->filter(fn ($column) => $column->isSearchable())->keys()),
             'resourceTableIndividuallySearchableColumns' => $this->convertDoubleQuotedArrayString($columns->filter(fn ($column) => $column->isIndividuallySearchable())->keys()),
-            'modelUsesSoftDeletes' => method_exists($model, 'trashed'), // check if the model uses SoftDeletes trait
         ];
     }
 

--- a/src/Commands/FilamentResourceTestsCommand.php
+++ b/src/Commands/FilamentResourceTestsCommand.php
@@ -142,6 +142,7 @@ class FilamentResourceTestsCommand extends Command
             'resourceTableSortableColumns' => $this->convertDoubleQuotedArrayString($columns->filter(fn ($column) => $column->isSortable())->keys()),
             'resourceTableSearchableColumns' => $this->convertDoubleQuotedArrayString($columns->filter(fn ($column) => $column->isSearchable())->keys()),
             'resourceTableIndividuallySearchableColumns' => $this->convertDoubleQuotedArrayString($columns->filter(fn ($column) => $column->isIndividuallySearchable())->keys()),
+            'modelUsesSoftDeletes' => method_exists($model, 'trashed'), // check if the model uses SoftDeletes trait
         ];
     }
 

--- a/stubs/Resource.stub
+++ b/stubs/Resource.stub
@@ -5,7 +5,7 @@ use $model$;
 use App\Models\User;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Hash;
-use App\Filament\Tables\Actions\DeleteAction;
+use Filament\Tables\Actions\DeleteAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;

--- a/stubs/Resource.stub
+++ b/stubs/Resource.stub
@@ -5,7 +5,7 @@ use $model$;
 use App\Models\User;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Hash;
-use Filament\Tables\Actions\DeleteAction;
+use App\Filament\Tables\Actions\DeleteAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;

--- a/stubs/Resource.stub
+++ b/stubs/Resource.stub
@@ -3,6 +3,7 @@
 use App\Filament\Resources\$resource$\Pages\List$modelPluralName$;
 use $model$;
 use App\Models\User;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Hash;
 use Filament\Tables\Actions\DeleteAction;
 
@@ -11,6 +12,8 @@ use function Pest\Livewire\livewire;
 
 
 beforeEach(function () {
+    $this->modelUsesSoftDeletes = in_array(SoftDeletes::class, class_uses_recursive($modelSingularName$::class));
+
     actingAs(User::factory()->create([
         'password' => Hash::make('password'),
     ]));
@@ -69,7 +72,7 @@ it('can delete records', function () {
     livewire(List$modelPluralName$::class)
         ->callTableAction(DeleteAction::class, $record);
 
-    if ($modelUsesSoftDeletes$) {
+    if ($this->modelUsesSoftDeletes) {
         $this->assertSoftDeleted($record);
     } else {
         $this->assertModelMissing($record);

--- a/stubs/Resource.stub
+++ b/stubs/Resource.stub
@@ -4,6 +4,7 @@ use App\Filament\Resources\$resource$\Pages\List$modelPluralName$;
 use $model$;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
+use Filament\Tables\Actions\DeleteAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -62,5 +63,16 @@ it('can individually search by column', function (string $column) {
         ->assertCanNotSeeTableRecords($records->where($column, '!=', $search));
 })->with($resourceTableIndividuallySearchableColumns$);
 
+it('can delete records', function () {
+    $record = $modelSingularName$::factory()->create();
 
+    livewire(List$modelPluralName$::class)
+        ->callTableAction(DeleteAction::class, $record);
+
+    if ($modelUsesSoftDeletes$) {
+        $this->assertSoftDeleted($record);
+    } else {
+        $this->assertModelMissing($record);
+    }
+});
 


### PR DESCRIPTION
This PR adds the ability to check if a delete action can be run. It runs the appropriate assertion depending on if the model uses soft deletes or not

Depends on #45 