### PR TITLE
Remove unused methods

### DIFF
--- a/src/Commands/FilamentResourceTestsCommand.php
+++ b/src/Commands/FilamentResourceTestsCommand.php
@@ -161,17 +161,7 @@ class FilamentResourceTestsCommand extends Command
     {
         return $table->getColumns();
     }
-
-    protected function getResourceSortableTableColumns(array $columns): Collection
-    {
-        return collect($columns)->filter(fn ($column) => $column->isSortable());
-    }
-
-    protected function getResourceSearchableTableColumns(array $columns): Collection
-    {
-        return collect($columns)->filter(fn ($column) => $column->isSearchable());
-    }
-
+    
     protected function getResourceTableFilters(Table $table): array
     {
         return $table->getFilters();

--- a/src/Commands/FilamentResourceTestsCommand.php
+++ b/src/Commands/FilamentResourceTestsCommand.php
@@ -161,7 +161,7 @@ class FilamentResourceTestsCommand extends Command
     {
         return $table->getColumns();
     }
-    
+
     protected function getResourceTableFilters(Table $table): array
     {
         return $table->getFilters();


### PR DESCRIPTION
Currently all the checks are performed on the given collection of columns upon setting the stub variables