### PR TITLE
Add a global group to tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can run your tests normally by running the following command:
 vendor/bin/pest
 ```
 
-You can choose only run the tests for this package by running the following command:
+You can choose to only run the tests for this package by running the following command:
 
 ```bash
 vendor/bin/pest --group=filament-resource-tests

--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ If you don't specify a resource name, the package will ask you to choose one fro
 php artisan make:filament-resource-test
 ````
 
+## Running the package tests
+
+You can run your tests normally by running the following command:
+
+```bash
+vendor/bin/pest
+```
+
+You can choose only run the tests for this package by running the following command:
+
+```bash
+vendor/bin/pest --group=filament-resource-tests
+```
+
+You can also run all your tests except the ones for this package by running the following command:
+
+```bash
+vendor/bin/pest --exclude-group=filament-resource-tests
+```
+
 ## Credits
 
 - [CodeWithDennis](https://github.com/CodeWithDennis)

--- a/stubs/Resource.stub
+++ b/stubs/Resource.stub
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Hash;
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 
+uses()->group('filament-resource-tests');
 
 beforeEach(function () {
     actingAs(User::factory()->create([


### PR DESCRIPTION
This PR adds the group to all generated tests which makes it easy to either run only the package tests or all tests except the package tests.

https://pestphp.com/docs/grouping-tests

Pest supports:
  --group [name]
  --exclude-group [name]