### PR TITLE
Fix Pest v3 dependency 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": "^8.1",
     "spatie/laravel-package-tools": "^1.14.0",
     "illuminate/contracts": "^10.0|^11.0",
-    "pestphp/pest-plugin-livewire": "^2.1"
+    "pestphp/pest-plugin-livewire": "^2.1|^3.0"
   },
   "require-dev": {
     "laravel/pint": "^1.14",

--- a/composer.json
+++ b/composer.json
@@ -1,66 +1,66 @@
 {
-    "name": "codewithdennis/filament-tests",
-    "description": "A package that creates PEST tests specifically tailored for your filament resources",
-    "keywords": [
-        "laravel",
-        "filament-tests",
-        "filamentphp",
-        "php",
-        "pest"
-    ],
-    "homepage": "https://github.com/codewithdennis/filament-tests",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "CodeWithDennis",
-            "role": "Developer"
-        }
-    ],
-    "require": {
-        "php": "^8.1",
-        "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0|^11.0",
-        "pestphp/pest-plugin-livewire": "^2.1"
-    },
-    "require-dev": {
-        "laravel/pint": "^1.14",
-        "nunomaduro/collision": "^7.8",
-        "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "CodeWithDennis\\FilamentTests\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "CodeWithDennis\\FilamentTests\\Tests\\": "tests/"
-        }
-    },
-    "scripts": {
-        "start": [
-            "Composer\\Config::disableProcessTimeout",
-            "@composer run build"
-        ]
-    },
-    "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "pestphp/pest-plugin": true,
-            "phpstan/extension-installer": true
-        }
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "CodeWithDennis\\FilamentTests\\FilamentTestsServiceProvider"
-            ],
-            "aliases": {
-                "FilamentTests": "CodeWithDennis\\FilamentTests\\Facades\\FilamentTests"
-            }
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+  "name": "codewithdennis/filament-tests",
+  "description": "A package that creates PEST tests specifically tailored for your filament resources",
+  "keywords": [
+    "laravel",
+    "filament-tests",
+    "filamentphp",
+    "php",
+    "pest"
+  ],
+  "homepage": "https://github.com/codewithdennis/filament-tests",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "CodeWithDennis",
+      "role": "Developer"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "spatie/laravel-package-tools": "^1.14.0",
+    "illuminate/contracts": "^10.0|^11.0",
+    "pestphp/pest-plugin-livewire": "^2.1|^3.0"
+  },
+  "require-dev": {
+    "laravel/pint": "^1.14",
+    "nunomaduro/collision": "^7.8",
+    "phpstan/extension-installer": "^1.1",
+    "phpstan/phpstan-deprecation-rules": "^1.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "CodeWithDennis\\FilamentTests\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "CodeWithDennis\\FilamentTests\\Tests\\": "tests/"
+    }
+  },
+  "scripts": {
+    "start": [
+      "Composer\\Config::disableProcessTimeout",
+      "@composer run build"
+    ]
+  },
+  "config": {
+    "sort-packages": true,
+    "allow-plugins": {
+      "pestphp/pest-plugin": true,
+      "phpstan/extension-installer": true
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "CodeWithDennis\\FilamentTests\\FilamentTestsServiceProvider"
+      ],
+      "aliases": {
+        "FilamentTests": "CodeWithDennis\\FilamentTests\\Facades\\FilamentTests"
+      }
+    }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": "^8.1",
     "spatie/laravel-package-tools": "^1.14.0",
     "illuminate/contracts": "^10.0|^11.0",
-    "pestphp/pest-plugin-livewire": "^2.1|^3.0"
+    "pestphp/pest-plugin-livewire": "^2.1"
   },
   "require-dev": {
     "laravel/pint": "^1.14",


### PR DESCRIPTION
This PR should fix an issue when your project is already using Pest v3 and related plugins. This now adds support for v3 too

> Problem 1
    - Root composer.json requires codewithdennis/filament-tests * -> satisfiable by codewithdennis/filament-tests[dev-main, dev-fix-pest3-dep].
    - codewithdennis/filament-tests[dev-main, dev-fix-pest3-dep] require pestphp/pest-plugin-livewire ^2.1 -> found pestphp/pest-plugin-livewire[v2.1.0, 2.x-dev] but it conflicts with your root composer.json require (^3.0).
