### PR TITLE
Replace table loading selection with confirmation prompt in user inpu…

### DIFF
--- a/src/Concerns/Commands/InteractsWithUserInput.php
+++ b/src/Concerns/Commands/InteractsWithUserInput.php
@@ -6,8 +6,8 @@ use Filament\Facades\Filament;
 use Filament\Panel;
 use Illuminate\Support\Collection;
 
+use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\multiselect;
-use function Laravel\Prompts\select;
 
 trait InteractsWithUserInput
 {
@@ -68,14 +68,10 @@ trait InteractsWithUserInput
 
     protected function askUserIfTableLoadingIsGloballyDeferred(): bool
     {
-        return (bool) select(
+        return confirm(
             label: 'Do you globally defer table loading in your Filament app?',
-            options: [
-                1 => 'Yes',
-                0 => 'No',
-            ],
+            default: false,
             hint: 'If you set `deferLoading` individually on your resource tables, you can select "No" here.',
-            required: true,
         );
     }
 }


### PR DESCRIPTION
Both the "overwrite" and "global deferring" are now in the same style. Also this is now selectable with keyboard (y or n). Also set the default to no (which is the more common default?)

Before:

https://github.com/user-attachments/assets/644da9d3-b09e-4cf7-b73a-b912f8928950


After:

https://github.com/user-attachments/assets/e0163192-d886-4f8a-ac24-04c3542109f1




