### PR TITLE
Proposal: Add tests for column state and formatted state validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ This package generates comprehensive PEST tests for your Filament resources. Her
 - **ShowsColumnTest** - Tests that explicitly visible columns are shown
 - **HidesColumnTest** - Tests that explicitly hidden columns are hidden
 - **CanNotDisplayTrashedRecordsByDefault** - Tests that trashed records are not displayed by default if soft deletes are enabled
+- **ColumnHasCorrectStateTest** - Tests that columns has the correct state
+- **ColumnHasCorrectFormattedStateTest** - Tests that columns has the correct formatted state (additional user input required)
 
 ### Table Functionality Tests
 - **CanSearchColumnTest** - Tests that searchable columns work correctly

--- a/resources/views/resources/pages/index/column-has-correct-formatted-state.blade.php
+++ b/resources/views/resources/pages/index/column-has-correct-formatted-state.blade.php
@@ -1,0 +1,20 @@
+it('`:dataset` column has the correct formatted state', function (string $column): void {
+    $records = {{ $getResourceModel() }}::factory(3)->create();
+
+    $record = $records->first();
+
+    $value = data_get($record, $column);
+
+//     if ($value instanceof Carbon\Carbon || $value instanceof Carbon\CarbonImmutable ) {
+//        $value = $value->format('Y-m-d H:i:s');
+//     }
+
+    livewire({{ $getPageClass('index') }}::class)
+        ->assertTableColumnFormattedStateSet($column, $value, record: $record)
+        ->assertTableColumnFormattedStateNotSet($column, 'non-existent-value', record: $record);
+{{-- TODO: support all column types --}}
+})->with([@foreach ($getResourceTableTextColumnKeys() as $column)'{{ $column }}',@endforeach])
+@if(count($diff = array_diff($getResourceTableVisibleColumnKeys(), $getResourceTableTextColumnKeys())) > 0)
+    ->todo('The following columns were skipped during generation as their state could not be determined automatically: {{ implode(", ", $diff) }}')
+@endif
+    ->skip('This test requires additional attention because the formatted state is likely to differ from the raw state.');

--- a/resources/views/resources/pages/index/column-has-correct-state.blade.php
+++ b/resources/views/resources/pages/index/column-has-correct-state.blade.php
@@ -1,0 +1,19 @@
+it('`:dataset` column has the correct state', function (string $column): void {
+    $records = {{ $getResourceModel() }}::factory(3)->create();
+
+    $record = $records->first();
+
+    $value = data_get($record, $column);
+
+    if ($value instanceof Carbon\Carbon || $value instanceof Carbon\CarbonImmutable ) {
+        $value = $value->toDateTimeString();
+    }
+
+    livewire({{ $getPageClass('index') }}::class)
+        ->assertTableColumnStateSet($column, $value, record: $record)
+        ->assertTableColumnStateNotSet($column, 'non-existent-value', record: $record);
+})@if(count($diff = array_diff($getResourceTableVisibleColumnKeys(), $getResourceTableTextColumnKeys())) > 0)
+    ->todo('The following columns were skipped during generation as their state could not be determined automatically: {{ implode(", ", $diff) }}')
+@endif
+{{-- TODO: support all column types --}}
+->with([@foreach ($getResourceTableTextColumnKeys() as $column)'{{ $column }}',@endforeach]);

--- a/src/Commands/FilamentTestsCommand.php
+++ b/src/Commands/FilamentTestsCommand.php
@@ -15,6 +15,8 @@ use CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index\CanRenderCo
 use CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index\CanRenderIndexPageTest;
 use CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index\CanSearchColumnTest;
 use CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index\CanSortColumnTest;
+use CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index\ColumnHasCorrectFormattedStateTest;
+use CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index\ColumnHasCorrectStateTest;
 use CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index\HasColumnTest;
 use CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index\HidesColumnTest;
 use CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index\ShowsColumnTest;
@@ -70,6 +72,8 @@ class FilamentTestsCommand extends Command
             CanSearchColumnTest::class,
             CanDeleteRecordTest::class,
             CanNotDisplayTrashedRecordsByDefault::class,
+            ColumnHasCorrectStateTest::class,
+            ColumnHasCorrectFormattedStateTest::class,
         ];
     }
 }

--- a/src/Concerns/Resources/InteractsWithTables.php
+++ b/src/Concerns/Resources/InteractsWithTables.php
@@ -64,6 +64,17 @@ trait InteractsWithTables
             ->filter(fn (Column $column): bool => $column->isVisible());
     }
 
+    public function getResourceTableTextColumns(): Collection
+    {
+        return $this->getResourceTableColumns()
+            ->filter(fn (Column $column): bool => $column instanceof \Filament\Tables\Columns\TextColumn);
+    }
+
+    public function getResourceTableTextColumnKeys(): array
+    {
+        return $this->getResourceTableColumnKeysFrom($this->getResourceTableTextColumns());
+    }
+
     public function getResourceTableVisibleColumnKeys(): array
     {
         return $this->getResourceTableColumnKeysFrom($this->getResourceTableVisibleColumns());

--- a/src/TestRenderers/Resources/Pages/Index/ColumnHasCorrectFormattedStateTest.php
+++ b/src/TestRenderers/Resources/Pages/Index/ColumnHasCorrectFormattedStateTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index;
+
+use CodeWithDennis\FilamentTests\TestRenderers\BaseTest;
+
+class ColumnHasCorrectFormattedStateTest extends BaseTest
+{
+    public ?string $view = 'filament-tests::resources.pages.index.column-has-correct-formatted-state';
+
+    public function getShouldRender(): bool
+    {
+        return $this->hasPage('index')
+            && $this->getResourceTableVisibleColumns()->isNotEmpty();
+    }
+}

--- a/src/TestRenderers/Resources/Pages/Index/ColumnHasCorrectStateTest.php
+++ b/src/TestRenderers/Resources/Pages/Index/ColumnHasCorrectStateTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index;
+
+use CodeWithDennis\FilamentTests\TestRenderers\BaseTest;
+
+class ColumnHasCorrectStateTest extends BaseTest
+{
+    public ?string $view = 'filament-tests::resources.pages.index.column-has-correct-state';
+
+    public function getShouldRender(): bool
+    {
+        return $this->hasPage('index')
+            && $this->getResourceTableVisibleColumns()->isNotEmpty();
+    }
+}


### PR DESCRIPTION
Let me know

```php
it('`:dataset` column has the correct state', function (string $column): void {
    $records = App\Models\User::factory(3)->create();

    $record = $records->first();

    $value = data_get($record, $column);

    if ($value instanceof Carbon\Carbon || $value instanceof Carbon\CarbonImmutable) {
        $value = $value->toDateTimeString();
    }

    livewire(App\Filament\Resources\Users\Pages\ListUsers::class)
        ->assertTableColumnStateSet($column, $value, record: $record)
        ->assertTableColumnStateNotSet($column, 'non-existent-value', record: $record);
})
    ->with(['name', 'email', 'email_verified_at', 'created_at', 'updated_at']);

it('`:dataset` column has the correct formatted state', function (string $column): void {
    $records = App\Models\User::factory(3)->create();

    $record = $records->first();

    $value = data_get($record, $column);

    //     if ($value instanceof Carbon\Carbon || $value instanceof Carbon\CarbonImmutable ) {
    //        $value = $value->format('Y-m-d H:i:s');
    //     }

    livewire(App\Filament\Resources\Users\Pages\ListUsers::class)
        ->assertTableColumnFormattedStateSet($column, $value, record: $record)
        ->assertTableColumnFormattedStateNotSet($column, 'non-existent-value', record: $record);

})->with(['name', 'email', 'email_verified_at', 'created_at', 'updated_at'])
    ->skip('This test requires additional attention because the formatted state is likely to differ from the raw state.');
```