### PR TITLE
Fix test counter

### DIFF
--- a/src/Concerns/Commands/InteractsWithFilesystem.php
+++ b/src/Concerns/Commands/InteractsWithFilesystem.php
@@ -63,8 +63,9 @@ trait InteractsWithFilesystem
 
         $this->generatedFiles[$panelKey][$resource] = [
             'path' => $filePath,
-            'num_tests' => (int) $renderResult['num_tests'] - 1, // -1 for the BeforeEach
+            'num_tests' => BaseTest::getGeneratedTestsCounter(),
         ];
+
     }
 
     protected function generateTests(): void
@@ -75,10 +76,13 @@ trait InteractsWithFilesystem
                     ->flatten()
                     ->each(fn (string $resourceClass) => $this->generateTestsForSelectedResource($resourceClass, $panelId));
             });
+
     }
 
     protected function renderTestsForResource(string $resource): array
     {
+        BaseTest::resetGeneratedTestsCounter();
+
         $renderers = collect($this->getRenderers());
 
         $output = $renderers
@@ -90,7 +94,7 @@ trait InteractsWithFilesystem
 
         return [
             'content' => $output,
-            'num_tests' => $renderers->count(),
+            'num_tests' => BaseTest::getGeneratedTestsCounter(),
         ];
     }
 

--- a/src/Concerns/Commands/InteractsWithFilesystem.php
+++ b/src/Concerns/Commands/InteractsWithFilesystem.php
@@ -54,16 +54,16 @@ trait InteractsWithFilesystem
             return;
         }
 
-        $renderResult = $this->renderTestsForResource($resource);
+        $renderedTests = $this->renderTestsForResource($resource);
 
         File::ensureDirectoryExists(dirname((string) $filePath));
-        File::put($filePath, $renderResult['content']);
+        File::put($filePath, $renderedTests['content']);
 
         $panelKey = $panel ?? 'default';
 
         $this->generatedFiles[$panelKey][$resource] = [
             'path' => $filePath,
-            'num_tests' => $renderResult['num_tests'],
+            'num_tests' => $renderedTests['num_tests'],
         ];
 
     }

--- a/src/Concerns/Commands/InteractsWithFilesystem.php
+++ b/src/Concerns/Commands/InteractsWithFilesystem.php
@@ -63,7 +63,7 @@ trait InteractsWithFilesystem
 
         $this->generatedFiles[$panelKey][$resource] = [
             'path' => $filePath,
-            'num_tests' => BaseTest::getGeneratedTestsCounter(),
+            'num_tests' => $renderResult['num_tests'],
         ];
 
     }

--- a/src/Concerns/Renderers/CanRenderViews.php
+++ b/src/Concerns/Renderers/CanRenderViews.php
@@ -39,11 +39,23 @@ trait CanRenderViews
     public function render(): ?string
     {
         try {
-            $result = $this->when($this->getShouldRender(), fn () => view($this->view, [
-                ...$this->extractPublicMethods($this),
-            ])->render());
+            if (! $this->getShouldRender()) {
+                return null;
+            }
 
-            return is_string($result) ? $result : null;
+            $rendered = view($this->view, [
+                ...$this->extractPublicMethods($this),
+            ])->render();
+
+            if (is_string($rendered)) {
+
+                self::$generatedTestsCounter++;
+
+                return $rendered;
+            }
+
+            return null;
+
         } catch (\Throwable $e) {
             return $e->getMessage();
         }

--- a/src/TestRenderers/BaseTest.php
+++ b/src/TestRenderers/BaseTest.php
@@ -16,6 +16,8 @@ abstract class BaseTest implements HasFilamentResources
     use InteractsWithGlobalConfiguration;
     use InteractsWithResources;
 
+    public static int $generatedTestsCounter = -1;
+
     public function __construct(
         public ?string $resourceClass = null,
     ) {}
@@ -23,6 +25,16 @@ abstract class BaseTest implements HasFilamentResources
     public static function build(string $resourceClass): static
     {
         return new static($resourceClass);
+    }
+
+    public static function getGeneratedTestsCounter(): int
+    {
+        return self::$generatedTestsCounter;
+    }
+
+    public static function resetGeneratedTestsCounter(): void
+    {
+        self::$generatedTestsCounter = -1;
     }
 
     public function getResourceClass(): ?string


### PR DESCRIPTION
This now takes into account if the tests are actually being rendered as opposed to before, where it would just increment for each `Renderer` regardless