### PR TITLE
Refactors summary two use `twoColumnDetail` instead of `table`

### DIFF
--- a/src/Concerns/Commands/InteractsWithFilesystem.php
+++ b/src/Concerns/Commands/InteractsWithFilesystem.php
@@ -68,7 +68,7 @@ trait InteractsWithFilesystem
         $renderedTests = $this->renderTestsForResource($resource);
         $endTime = microtime(true);
 
-        $duration = round(($endTime - $startTime) * 1000, 2, PHP_ROUND_HALF_UP);
+        $duration = round(($endTime - $startTime) * 1000, mode: PHP_ROUND_HALF_UP);
 
         File::ensureDirectoryExists(dirname((string) $filePath));
         File::put($filePath, $renderedTests['content']);

--- a/src/Concerns/Commands/InteractsWithFilesystem.php
+++ b/src/Concerns/Commands/InteractsWithFilesystem.php
@@ -63,8 +63,9 @@ trait InteractsWithFilesystem
 
         $this->generatedFiles[$panelKey][$resource] = [
             'path' => $filePath,
-            'num_tests' => (int) $renderResult['num_tests'] - 1, // -1 for the BeforeEach
+            'num_tests' => BaseTest::getGeneratedTestsCounter(),
         ];
+
     }
 
     protected function generateTests(): void
@@ -75,10 +76,13 @@ trait InteractsWithFilesystem
                     ->flatten()
                     ->each(fn (string $resourceClass) => $this->generateTestsForSelectedResource($resourceClass, $panelId));
             });
+
     }
 
     protected function renderTestsForResource(string $resource): array
     {
+        BaseTest::resetGeneratedTestsCounter();
+
         $renderers = collect($this->getRenderers());
 
         $output = $renderers
@@ -90,7 +94,7 @@ trait InteractsWithFilesystem
 
         return [
             'content' => $output,
-            'num_tests' => $renderers->count(),
+            'num_tests' => BaseTest::getGeneratedTestsCounter(),
         ];
     }
 

--- a/src/Concerns/Commands/InteractsWithFilesystem.php
+++ b/src/Concerns/Commands/InteractsWithFilesystem.php
@@ -8,16 +8,21 @@ use Illuminate\Support\Facades\Process;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\info;
-use function Laravel\Prompts\table;
-use function Laravel\Prompts\warning;
 
 trait InteractsWithFilesystem
 {
     protected array $generatedFiles = [];
 
+    protected array $skippedFiles = [];
+
     protected function getGeneratedFiles(): array
     {
         return $this->generatedFiles;
+    }
+
+    protected function getSkippedFiles(): array
+    {
+        return $this->skippedFiles;
     }
 
     protected function runPintOnGeneratedTests(): void
@@ -51,19 +56,27 @@ trait InteractsWithFilesystem
         if (File::exists($filePath) && ! $force && ! confirm("The tests for {$resource} already exists. Do you want to overwrite it?", false)) {
             info("Skipped generating test for {$resource}.");
 
+            $this->skippedFiles[$panel][$resource] = [
+                'path' => $filePath,
+                'duration' => 0,
+            ];
+
             return;
         }
 
+        $startTime = microtime(true);
         $renderedTests = $this->renderTestsForResource($resource);
+        $endTime = microtime(true);
+
+        $duration = round(($endTime - $startTime) * 1000, 2, PHP_ROUND_HALF_UP);
 
         File::ensureDirectoryExists(dirname((string) $filePath));
         File::put($filePath, $renderedTests['content']);
 
-        $panelKey = $panel ?? 'default';
-
-        $this->generatedFiles[$panelKey][$resource] = [
+        $this->generatedFiles[$panel][$resource] = [
             'path' => $filePath,
             'num_tests' => $renderedTests['num_tests'],
+            'duration' => $duration,
         ];
 
     }
@@ -100,26 +113,63 @@ trait InteractsWithFilesystem
 
     protected function showGenerationSummary(): void
     {
-        if (blank($this->getGeneratedFiles())) {
-            warning('No test files were generated.');
+        if (blank($this->getGeneratedFiles()) && blank($this->getSkippedFiles())) {
+            $this->components->warn('No test files were generated.');
 
             return;
         }
 
-        $rows = collect($this->getGeneratedFiles())
-            ->flatMap(fn (array $resources, string $panelName) => collect($resources)
-                ->map(fn (array $data, string $resource): array => [
-                    $resource,
-                    $panelName,
-                    $data['num_tests'] ?? 0,
-                ])
-            )
-            ->values()
-            ->all();
+        $this->newLine();
 
-        table(
-            ['Resource', 'Panel', '# Tests'],
-            $rows
-        );
+        $allPanels = collect($this->getGeneratedFiles())
+            ->keys()
+            ->merge(collect($this->getSkippedFiles())->keys())
+            ->unique()
+            ->sort();
+
+        $totalTests = 0;
+        $totalFiles = 0;
+        $totalDuration = 0;
+
+        foreach ($allPanels as $panelId) {
+            $generatedResources = $this->getGeneratedFiles()[$panelId] ?? [];
+
+            foreach ($generatedResources as $resource => $data) {
+                $numTests = $data['num_tests'] ?? 0;
+                $duration = $data['duration'] ?? 0;
+                $totalTests += $numTests;
+                $totalFiles++;
+                $totalDuration += $duration;
+
+                $this->displayResourceSummary($resource, $panelId, $numTests, 'SUCCESS');
+            }
+
+            $skippedResources = $this->getSkippedFiles()[$panelId] ?? [];
+            foreach ($skippedResources as $resource => $data) {
+                $duration = $data['duration'] ?? 0;
+                $totalFiles++;
+                $totalDuration += $duration;
+
+                $this->displayResourceSummary($resource, $panelId, 0, 'SKIPPED');
+            }
+        }
+
+        $this->newLine();
+        $this->components->twoColumnDetail('Total No. of Resources', "<options=bold>{$totalFiles}</>");
+        $this->components->twoColumnDetail('Total Duration', "<options=bold>{$totalDuration} ms</>");
+        $this->components->twoColumnDetail('Total No. of Tests', "<options=bold>{$totalTests}</>");
+        $this->newLine();
+    }
+
+    protected function displayResourceSummary(string $resource, string $panelId, int $numTests, string $status): void
+    {
+        $resourceName = class_basename($resource);
+
+        $resourceDisplay = $resourceName.' <fg=gray>('.strtolower($panelId).')</>';
+
+        $statusColor = $status === 'SUCCESS' ? 'green' : 'yellow';
+        $statusDisplay = "<fg=gray>({$numTests} Tests)</> <fg={$statusColor};options=bold>{$status}</>";
+
+        $this->components->twoColumnDetail($resourceDisplay, $statusDisplay);
     }
 }

--- a/src/Concerns/Commands/InteractsWithFilesystem.php
+++ b/src/Concerns/Commands/InteractsWithFilesystem.php
@@ -54,16 +54,16 @@ trait InteractsWithFilesystem
             return;
         }
 
-        $renderResult = $this->renderTestsForResource($resource);
+        $renderedTests = $this->renderTestsForResource($resource);
 
         File::ensureDirectoryExists(dirname((string) $filePath));
-        File::put($filePath, $renderResult['content']);
+        File::put($filePath, $renderedTests['content']);
 
         $panelKey = $panel ?? 'default';
 
         $this->generatedFiles[$panelKey][$resource] = [
             'path' => $filePath,
-            'num_tests' => $renderResult['num_tests'],
+            'num_tests' => $renderedTests['num_tests'],
         ];
 
     }

--- a/src/Concerns/Commands/InteractsWithFilesystem.php
+++ b/src/Concerns/Commands/InteractsWithFilesystem.php
@@ -63,7 +63,7 @@ trait InteractsWithFilesystem
 
         $this->generatedFiles[$panelKey][$resource] = [
             'path' => $filePath,
-            'num_tests' => BaseTest::getGeneratedTestsCounter(),
+            'num_tests' => $renderResult['num_tests'],
         ];
 
     }

--- a/src/Concerns/Renderers/CanRenderViews.php
+++ b/src/Concerns/Renderers/CanRenderViews.php
@@ -39,11 +39,23 @@ trait CanRenderViews
     public function render(): ?string
     {
         try {
-            $result = $this->when($this->getShouldRender(), fn () => view($this->view, [
-                ...$this->extractPublicMethods($this),
-            ])->render());
+            if (! $this->getShouldRender()) {
+                return null;
+            }
 
-            return is_string($result) ? $result : null;
+            $rendered = view($this->view, [
+                ...$this->extractPublicMethods($this),
+            ])->render();
+
+            if (is_string($rendered)) {
+
+                self::$generatedTestsCounter++;
+
+                return $rendered;
+            }
+
+            return null;
+
         } catch (\Throwable $e) {
             return $e->getMessage();
         }

--- a/src/TestRenderers/BaseTest.php
+++ b/src/TestRenderers/BaseTest.php
@@ -16,6 +16,8 @@ abstract class BaseTest implements HasFilamentResources
     use InteractsWithGlobalConfiguration;
     use InteractsWithResources;
 
+    public static int $generatedTestsCounter = -1;
+
     public function __construct(
         public ?string $resourceClass = null,
     ) {}
@@ -23,6 +25,16 @@ abstract class BaseTest implements HasFilamentResources
     public static function build(string $resourceClass): static
     {
         return new static($resourceClass);
+    }
+
+    public static function getGeneratedTestsCounter(): int
+    {
+        return self::$generatedTestsCounter;
+    }
+
+    public static function resetGeneratedTestsCounter(): void
+    {
+        self::$generatedTestsCounter = -1;
     }
 
     public function getResourceClass(): ?string


### PR DESCRIPTION
Depends on #326 

# Before
<img width="725" height="147" alt="Screenshot 2025-09-09 153144" src="https://github.com/user-attachments/assets/41cafa57-ef96-4e3a-80a2-4fe4c0a386d7" />

# After
<img width="1518" height="252" alt="Screenshot 2025-09-09 161811" src="https://github.com/user-attachments/assets/24f23df2-8a4f-465a-9aa8-c379a5942f55" />
