### PR TITLE
Add SelectColumnHasOptionsTest to verify select column options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This package generates comprehensive PEST tests for your Filament resources. Her
 - **CanNotDisplayTrashedRecordsByDefault** - Tests that trashed records are not displayed by default if soft deletes are enabled
 - **ColumnHasDescriptionBelowTest** - Tests that columns with descriptions display them below
 - **ColumnHasDescriptionAboveTest** - Tests that columns with descriptions display them above
+- **SelectColumnHasOptionsTest** - Tests that select columns have the correct options
 
 ### Table Functionality Tests
 - **CanSearchColumnTest** - Tests that searchable columns work correctly

--- a/resources/views/resources/pages/index/select-column-has-options.blade.php
+++ b/resources/views/resources/pages/index/select-column-has-options.blade.php
@@ -1,0 +1,12 @@
+it('`select-column :dataset` has the correct options', function (string $column, array $options): void {
+    $record = {{ $getResourceModel() }}::factory()->create();
+
+    livewire({{ $getPageClass('index') }}::class)
+        ->assertTableSelectColumnHasOptions($column, $options, $record);
+})->with([
+@foreach ($getResourceTableSelectColumns() as $column)
+    ['{{ $column->getName() }}',
+        {!! var_export($column->getOptions(), true) !!}
+    ],
+@endforeach
+]);

--- a/src/Commands/FilamentTestsCommand.php
+++ b/src/Commands/FilamentTestsCommand.php
@@ -22,6 +22,7 @@ use CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index\ColumnHasDe
 use CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index\ColumnHasDescriptionBelowTest;
 use CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index\HasColumnTest;
 use CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index\HidesColumnTest;
+use CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index\SelectColumnHasOptionsTest;
 use CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index\ShowsColumnTest;
 use CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\View\CanRenderViewPageTest;
 use Illuminate\Console\Command;
@@ -70,6 +71,7 @@ class FilamentTestsCommand extends Command
             HidesColumnTest::class,
             ColumnHasDescriptionAboveTest::class,
             ColumnHasDescriptionBelowTest::class,
+            SelectColumnHasOptionsTest::class,
             CanSortColumnTest::class,
             CanSearchColumnTest::class,
             CanSearchColumnIndividuallyTest::class,

--- a/src/Concerns/Resources/InteractsWithTables.php
+++ b/src/Concerns/Resources/InteractsWithTables.php
@@ -173,4 +173,10 @@ trait InteractsWithTables
         return $this->getResourceTableTextColumns()
             ->filter(fn (TextColumn $column): bool => filled($column->getDescriptionBelow()));
     }
+
+    public function getResourceTableSelectColumns(): Collection
+    {
+        return $this->getResourceTableColumns()
+            ->filter(fn (Column $column): bool => $column instanceof \Filament\Tables\Columns\SelectColumn);
+    }
 }

--- a/src/Concerns/Resources/InteractsWithTables.php
+++ b/src/Concerns/Resources/InteractsWithTables.php
@@ -174,7 +174,6 @@ trait InteractsWithTables
             ->filter(fn (TextColumn $column): bool => filled($column->getDescriptionBelow()));
     }
 
-
     public function getResourceTableSelectColumns(): Collection
     {
         return $this->getResourceTableColumns()

--- a/src/TestRenderers/Resources/Pages/Index/SelectColumnHasOptionsTest.php
+++ b/src/TestRenderers/Resources/Pages/Index/SelectColumnHasOptionsTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace CodeWithDennis\FilamentTests\TestRenderers\Resources\Pages\Index;
+
+use CodeWithDennis\FilamentTests\TestRenderers\BaseTest;
+
+class SelectColumnHasOptionsTest extends BaseTest
+{
+    public ?string $view = 'filament-tests::resources.pages.index.select-column-has-options';
+
+    public function getShouldRender(): bool
+    {
+        return $this->hasPage('index')
+            && $this->getResourceTableSelectColumns()->isNotEmpty();
+    }
+}


### PR DESCRIPTION
```php
it('`select-column :dataset` has the correct options', function (string $column, array $options): void {
    $record = App\Models\User::factory()->create();

    livewire(App\Filament\Resources\Users\Pages\ListUsers::class)
        ->assertTableSelectColumnHasOptions($column, $options, $record);
})->with([
    ['test',
        [
            'hi' => 'hello',
            2 => 'Test 2',
            3 => 'Test 3',
        ],
    ],
]);
```